### PR TITLE
Fixed undefined index exception in Twig ImageRuntime

### DIFF
--- a/src/Twig/Runtime/ImageRuntime.php
+++ b/src/Twig/Runtime/ImageRuntime.php
@@ -347,7 +347,7 @@ class ImageRuntime
         }
 
         return isset($fileName['filename']) ? $fileName['filename']
-            : isset($fileName['file']) ? $fileName['file'] : ''
+            : (isset($fileName['file']) ? $fileName['file'] : '')
         ;
     }
 }


### PR DESCRIPTION
Details
-------

Embedding an image (its URL respectively) in a twig-template using the {{ pictureObject|image }} syntax produces an "Undefined index 'file'" exception in bolt 3.6. This PR fixes this by correctly handling the different kinds of `$fileName` in `ImageRuntime::normalizeFileName($fileName)`. 